### PR TITLE
Add LocalFileWrapper and PathImporter (#91)

### DIFF
--- a/app/services/importers/filesystem.py
+++ b/app/services/importers/filesystem.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+from app.services.importers import BookImporter, DjvuImporter, EpubImporter, PdfImporter
+
+EXT_TO_IMPORTER: dict[str, type[BookImporter]] = {
+    '.pdf': PdfImporter,
+    '.epub': EpubImporter,
+    '.djvu': DjvuImporter,
+}
+
+
+@dataclass
+class LocalFileWrapper:
+    path: Path
+    _file: BinaryIO | None = None
+
+    @property
+    def filename(self) -> str:
+        return self.path.name
+
+    @property
+    def file(self) -> BinaryIO:
+        if self._file is None:
+            self._file = open(self.path, 'rb')  # noqa: SIM115
+        self._file.seek(0)
+        return self._file
+
+
+class PathImporter:
+    def __init__(self, path: Path, tags: set[str]):
+        ext = path.suffix.lower()
+        importer_cls = EXT_TO_IMPORTER.get(ext)
+        if importer_cls is None:
+            raise ValueError(f'Unsupported file extension: {ext}')
+        self._importer = importer_cls(LocalFileWrapper(path=path), tags)
+
+    def process(self, store):
+        self._importer.process(store)


### PR DESCRIPTION
- LocalFileWrapper — dataclass wrapping a Path that exposes .filename / .file to match UploadFile's interface
- PathImporter — resolves file extension to importer class via EXT_TO_IMPORTER, wraps path in LocalFileWrapper, delegates to format importer's process()
- New file: app/services/importers/filesystem.py