### PR TITLE
Add GET /sync endpoint with SyncService (#93)

### DIFF
--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from .books.sync import router as sync_router
 from .books.views import router as books_router
 from .database.views import router as db_router
 from .home.views import router as home_router
@@ -8,3 +9,4 @@ handlers_router = APIRouter()
 handlers_router.include_router(db_router, prefix="/db", tags=["Database"])
 handlers_router.include_router(books_router, prefix="/books", tags=["Books"])
 handlers_router.include_router(home_router, prefix="", tags=["Home"])
+handlers_router.include_router(sync_router, prefix="", tags=["Sync"])

--- a/app/handlers/books/sync.py
+++ b/app/handlers/books/sync.py
@@ -1,0 +1,31 @@
+import logging
+
+from fastapi import APIRouter, Depends, Request
+from starlette import status
+from starlette.responses import RedirectResponse
+
+from app.handlers.dependencies import get_data_store, get_sync_service
+from app.repositories.data_store import DataStore
+from app.services.sync_service import SyncService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get('/sync')
+def sync_books(
+    request: Request,
+    store: DataStore = Depends(get_data_store),
+    sync_service: SyncService = Depends(get_sync_service),
+):
+    logger.info('Sync requested')
+    result = sync_service.run(store)
+
+    parts = [f'Synced: {result.added} added, {result.skipped} skipped']
+    if result.errors:
+        parts.append(f'{len(result.errors)} errors')
+
+    logger.info('Redirecting with result: %s', ', '.join(parts))
+    url = request.url_for('homepage').include_query_params(sync_msg=', '.join(parts))
+    return RedirectResponse(url, status_code=status.HTTP_303_SEE_OTHER)

--- a/app/handlers/dependencies.py
+++ b/app/handlers/dependencies.py
@@ -7,7 +7,12 @@ from app.db import (
     get_db_session,
 )
 from app.repositories.data_store import DataStore
+from app.services.sync_service import SyncService
 
 
-def get_data_store(db_session: Session = Depends(get_db_session)):
+def get_data_store(db_session: Session = Depends(get_db_session)) -> DataStore:
     return DataStore(db_session)
+
+
+def get_sync_service() -> SyncService:
+    return SyncService()

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,8 @@
+import logging
+
+
+def setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,9 @@ from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
 from app.handlers import handlers_router
+from app.logging_config import setup_logging
+
+setup_logging()
 
 app = FastAPI(title='BookVault')
 app.add_middleware(GZipMiddleware, minimum_size=500)

--- a/app/services/directory_scanner.py
+++ b/app/services/directory_scanner.py
@@ -26,21 +26,28 @@ class DirectoryScanner:
         seen: set[Path] = set()
 
         for path in root.rglob('*'):
+            # cheap extension check first - filters most of the tree (no syscall)
+            if path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+                continue
+
+            # skip files inside hidden directories (prefixed with .)
+            if any(part.startswith('.') for part in path.relative_to(root).parts[:-1]):
+                continue
+
+            # stat only for candidates that passed cheap checks
+            if not path.is_file():
+                continue
+
+            # dedup via resolved path (catches symlink duplicates) - only on kept files
             try:
                 resolved = path.resolve()
             except (OSError, RuntimeError) as exc:
                 result.errors.append((path, str(exc)))
                 continue
-
             if resolved in seen:
                 continue
             seen.add(resolved)
 
-            # Skip files inside hidden directories (prefixed with .)
-            if any(part.startswith('.') for part in path.relative_to(root).parts[:-1]):
-                continue
-
-            if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS:
-                result.file_paths.append(path)
+            result.file_paths.append(path)
 
         return result

--- a/app/services/importers/base.py
+++ b/app/services/importers/base.py
@@ -12,6 +12,8 @@ from app.services.importers.exceptions import ImportBookException
 
 escaping_table = str.maketrans({'#': 'sharp'})
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class BookMetadata:
@@ -47,8 +49,9 @@ class BookImporter:
 
     def _calculate_checksum(self):
         file_hash = hashlib.blake2b()
-        self.file.file.seek(0)
-        while chunk := self.file.file.read(8192):
+        f = self.file.file
+        f.seek(0)
+        while chunk := f.read(8192):
             file_hash.update(chunk)
         return file_hash.hexdigest()
 
@@ -81,15 +84,15 @@ class BookImporter:
         db_publisher = store.publisher_repo.get_or_create(name=publisher_name)
         return db_publisher
 
-    def process(self, store: DataStore):
-        logging.info("Importing book")
-        logging.info("Filename: %s, tags: %s", self.file, self.tags)
+    def process(self, store: DataStore) -> bool:
+        logger.info("Importing book")
+        logger.info("Filename: %s, tags: %s", self.file, self.tags)
 
         try:
             book_metadata = self.get_metadata()
         except ImportBookException as e:
-            logging.error(f'Exception while importing {self.file}, {e}')
-            return
+            logger.error(f'Exception while importing {self.file}, {e}')
+            return False
 
         checksum = self._calculate_checksum()
         book = store.session.query(Book).filter(Book.checksum == checksum).first()
@@ -97,8 +100,8 @@ class BookImporter:
             # checksum matches but path differs - file was moved, update path
             if self.file_path and book.file_path != self.file_path:
                 book.file_path = self.file_path
-                logging.info(f"Updated file_path for book {book.id}: {self.file_path}")
-            return
+                logger.info(f"Updated file_path for book {book.id}: {self.file_path}")
+            return False
 
         lang_code = (book_metadata.languages or ['en'])[0]
         language = store.session.query(Language).filter(Language.code == lang_code).first()
@@ -123,3 +126,4 @@ class BookImporter:
             description=book_metadata.description,
             file_path=self.file_path,
         )
+        return True

--- a/app/services/importers/epub.py
+++ b/app/services/importers/epub.py
@@ -16,6 +16,8 @@ from app.services.importers.base import (
 )
 from app.services.importers.exceptions import ImportBookException
 
+logger = logging.getLogger(__name__)
+
 
 class EpubImporter(BookImporter):
     FORMAT = 'epub'
@@ -26,9 +28,9 @@ class EpubImporter(BookImporter):
 
     def get_metadata(self):
         try:
-            self.book = self._get_temp_ebook()
+            self.book = self._read_ebook()
         except Exception as e:
-            logging.info('Failed to import book')
+            logger.info('Failed to import book')
             raise ImportBookException from e
 
         title = self.book.get_metadata("DC", 'title')[0][0]
@@ -104,10 +106,17 @@ class EpubImporter(BookImporter):
         authors = cleaned_authors
         return authors
 
-    def _get_temp_ebook(self):
+    def _read_ebook(self):
+        """Read EPUB — use path directly for local files, temp file for uploads."""
+        path = getattr(self.file, 'path', None)
+        if path is not None:
+            logger.info('Reading EPUB from path: %s', self.file.filename)
+            return epub.read_epub(str(path))
         with NamedTemporaryFile(delete=False) as temp_file:
             shutil.copyfileobj(self.file.file, temp_file)
             temp_path = temp_file.name
-        book = epub.read_epub(temp_path)
-        os.unlink(temp_path)
+        try:
+            book = epub.read_epub(temp_path)
+        finally:
+            os.unlink(temp_path)
         return book

--- a/app/services/importers/filesystem.py
+++ b/app/services/importers/filesystem.py
@@ -26,7 +26,6 @@ class LocalFileWrapper:
     def file(self) -> BinaryIO:
         if self._file is None:
             self._file = open(self.path, 'rb')  # noqa: SIM115
-        self._file.seek(0)
         return self._file
 
 

--- a/app/services/importers/pdf.py
+++ b/app/services/importers/pdf.py
@@ -18,8 +18,13 @@ class PdfImporter(BookImporter):
         super().__init__(*args, **kwargs)
         self._pdf_buffer: BytesIO | None = None
 
-    def _get_pdf_buffer(self) -> BytesIO:
+    def _get_pdf_source(self) -> str | BytesIO:
+        """Return a path string for local files, BytesIO for uploads."""
+        path = getattr(self.file, 'path', None)
+        if path is not None:
+            return str(path)
         if self._pdf_buffer is None:
+            logger.info('Reading PDF into memory: %s', self.file.filename)
             self.file.file.seek(0)
             self._pdf_buffer = BytesIO(self.file.file.read())
         self._pdf_buffer.seek(0)
@@ -27,7 +32,8 @@ class PdfImporter(BookImporter):
 
     def extract_cover(self):
         filename = self._cover_filename
-        pdf = pdfium.PdfDocument(self._get_pdf_buffer())
+        logger.info('Rendering cover: %s', filename)
+        pdf = pdfium.PdfDocument(self._get_pdf_source())
         page = pdf.get_page(0)
         cover = page.render(scale=300 / 72, optimize_mode=None).to_pil()
         path = Path(settings.static_path, settings.cover_images_path, filename)
@@ -36,7 +42,8 @@ class PdfImporter(BookImporter):
         return filename
 
     def get_metadata(self):
-        pdf = PdfReader(self._get_pdf_buffer())
+        logger.info('Parsing PDF metadata: %s', self.file.filename)
+        pdf = PdfReader(self._get_pdf_source())
         pdf_info = pdf.metadata
         if pdf_info:
             description = pdf_info.get('/Description', pdf_info.get('/Subject')) or ''

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from app.config import settings
+from app.repositories.data_store import DataStore
+from app.services.directory_scanner import DirectoryScanner
+from app.services.importers.filesystem import PathImporter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SyncResult:
+    added: int = 0
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+class SyncService:
+    def run(self, store: DataStore) -> SyncResult:
+        result = SyncResult()
+
+        books_dir = Path(settings.books_directory)
+        if not books_dir or not books_dir.is_dir():
+            logger.error('BOOKS_DIRECTORY is not set or does not exist: %s', books_dir)
+            result.errors.append('BOOKS_DIRECTORY is not set or does not exist')
+            return result
+
+        logger.info('Sync started, scanning %s', books_dir)
+        scan_result = DirectoryScanner().scan(books_dir)
+        logger.info('Scan complete: %d files found, %d scan errors',
+                     len(scan_result.file_paths), len(scan_result.errors))
+
+        for error_path, error_msg in scan_result.errors:
+            logger.warning('Scan error: %s — %s', error_path, error_msg)
+            result.errors.append(f'{error_path}: {error_msg}')
+
+        total = len(scan_result.file_paths)
+        for idx, file_path in enumerate(scan_result.file_paths, start=1):
+            logger.info('Importing [%d/%d] %s', idx, total, file_path.name)
+            try:
+                importer = PathImporter(file_path, set())
+                with store.transaction():
+                    if importer.process(store):
+                        result.added += 1
+                    else:
+                        result.skipped += 1
+            except Exception:
+                logger.exception('Error importing %s', file_path)
+                result.errors.append(f'{file_path}: import failed')
+
+        logger.info('Sync finished: %d added, %d skipped, %d errors',
+                     result.added, result.skipped, len(result.errors))
+        return result

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,14 @@
     {% include "navbar.html" %}
 </header>
 
+{% set sync_msg = request.query_params.get('sync_msg', '') %}
+{% if sync_msg %}
+<div class="bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded relative" role="alert">
+    <span>{{ sync_msg }}</span>
+    <button class="absolute top-0 bottom-0 right-0 px-4 py-3" onclick="this.parentElement.style.display='none'">&times;</button>
+</div>
+{% endif %}
+
 {% block content %}
 {% endblock %}
 


### PR DESCRIPTION
- SyncService.run() scans BOOKS_DIRECTORY and imports via PathImporter, returns added/skipped/errors stats
- GET /sync handler injected via get_sync_service DI, redirects with flash message in query param
- Register sync_router in app/handlers/__init__.py
- Flash banner in templates/base.html
- BookImporter.process() returns bool (added vs skipped)
- Logging: app/logging_config.py setup_logging() called from main.py, module-level loggers replace root-logger calls in base.py/epub.py, step-level logs in sync flow and pdf/epub importers
- DirectoryScanner: reorder cheap checks (suffix, hidden) before syscalls (stat, resolve) to skip most of the tree for free
- PdfImporter/EpubImporter: read from path directly for LocalFileWrapper instead of slurping into BytesIO / temp file
- LocalFileWrapper.file: drop seek(0) side-effect that caused infinite loop in _calculate_checksum (property ran seek on every access)