### PR TITLE
Add Open button with eye icon to open books in native app (#102)

### DIFF
--- a/app/handlers/books/views.py
+++ b/app/handlers/books/views.py
@@ -1,9 +1,13 @@
+import subprocess
+from pathlib import Path
+
 from fastapi import (
     APIRouter,
     File,
     Form,
     HTTPException,
     Request,
+    Response,
     UploadFile,
 )
 from starlette import status
@@ -72,6 +76,25 @@ def show_book(
             detail=f"Book with id={book_id} not found",
         )
     return templates.TemplateResponse("book_view.html", {"request": request, "book": book, "tags": book.tags})
+
+
+@router.get("/{book_id}/download")
+def download_book(
+    request: Request,
+    book_id: int,
+    store: DataStoreDependency,
+):
+    book = store.book_repo.get_book_by_id(book_id)
+    if not book or not book.file_path:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+
+    file_path = Path(book.file_path)
+    if not file_path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found on disk")
+
+    # only works when server is on local machine (server and browser share filesystem)
+    subprocess.Popen(["open", str(file_path)])
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/by_tag/{tag_name}")

--- a/templates/book_view.html
+++ b/templates/book_view.html
@@ -8,7 +8,12 @@
         {% endif %}
     </div>
     <div class="info">
-        <h1>{{ book.title }}</h1>
+        <h1>{{ book.title }}
+            {% if book.file_path %}
+            <a hx-get="{{ url_for('download_book', book_id=book.id) }}" hx-swap="none"
+               class="inline-block ml-2 px-3 py-1 bg-blue-500 text-white rounded text-sm cursor-pointer">Open</a>
+            {% endif %}
+        </h1>
         <p><strong>Authors:</strong> {% for author in book.authors %} {{ author.name }} {% endfor %}</p>
         <p><strong>Edition:</strong> {{ book.edition }}</p>
         <p><strong>ISBN:</strong> {{ book.isbn }}</p>

--- a/templates/books_list.html
+++ b/templates/books_list.html
@@ -56,12 +56,21 @@
                     </div>
 
                     <!-- Cover -->
-                    <div class="col-span-1">
+                    <div class="col-span-1 flex flex-col items-center gap-1">
                         {% if book.cover %}
                         <div class="thumbnail_container">
                         <img class="book_list_thumbnail object-cover h-12 w-8"
                             src="{{ url_for('static', path='cover_images/' ~ book.cover) }}" alt="" loading="lazy">
                         </div>
+                        {% endif %}
+                        {% if book.file_path %}
+                        <a hx-get="{{ url_for('download_book', book_id=book.id) }}" hx-swap="none"
+                           class="text-gray-500 hover:text-blue-600 cursor-pointer" title="Open file">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                            </svg>
+                        </a>
                         {% endif %}
                     </div>
 


### PR DESCRIPTION
- Add GET /{book_id}/download endpoint. Uses subprocess.Popen(["open", file_path]) to launch the book in the default native application (Preview on macOS). Returns 204 No Content. Only works when server runs locally.
- Add "Open" button to book detail view (book_view.html)
- Add eye icon SVG to book list view (books_list.html) under the cover thumbnail
- Both buttons use hx-get with hx-swap="none" for silent fire-and-forget calls (no redirect, no page navigation)
- Only shown when book.file_path is set (synced books)