### PR TITLE
Add pagination to book list views (#101)

### DIFF
--- a/app/handlers/books/views.py
+++ b/app/handlers/books/views.py
@@ -6,6 +6,7 @@ from fastapi import (
     File,
     Form,
     HTTPException,
+    Query,
     Request,
     Response,
     UploadFile,
@@ -15,7 +16,7 @@ from starlette.responses import RedirectResponse
 
 from app.handlers.dependencies import DataStoreDependency
 from app.services.importers import DjvuImporter, EpubImporter, PdfImporter
-from app.template_utils import templates
+from app.template_utils import DEFAULT_PER_PAGE, Pagination, normalize_pagination, templates
 
 ALLOWED_TYPES = {
     "application/pdf": PdfImporter,
@@ -26,18 +27,39 @@ ALLOWED_TYPES = {
 router = APIRouter()
 
 
-@router.post("/search", summary="Search books", status_code=status.HTTP_200_OK)
+@router.get("/search", summary="Search books", status_code=status.HTTP_200_OK)
 def search_books(
     request: Request,
     store: DataStoreDependency,
-    query: str = Form(default=""),
+    query: str = Query(default=""),
+    page: int | None = None,
+    per_page: int | None = None,
 ):
+    page, per_page_size = normalize_pagination(page, per_page)
+    books, total, page = store.book_repo.get_searched_books(query, page=page, per_page=per_page_size)
     tags = []
-    books = store.book_repo.get_searched_books(query)
     for book in books:
         tags.extend(iter(book.tags))
     tags = sorted(set(tags), key=lambda tag: tag.name)
-    return templates.TemplateResponse("books_list.html", {"request": request, "books": books, "tags": tags})
+    pagination = Pagination(
+        request=request,
+        route_name="search_books",
+        page=page,
+        per_page=per_page_size,
+        total=total,
+        extra_query={"query": query} if query else {},
+    )
+    return templates.TemplateResponse(
+        "books_list.html",
+        {
+            "request": request,
+            "books": books,
+            "tags": tags,
+            "pagination": pagination,
+            "per_page": per_page_size,
+            "default_per_page": DEFAULT_PER_PAGE,
+        },
+    )
 
 
 @router.get("/add_books")
@@ -102,13 +124,34 @@ def show_books_by_tag(
     request: Request,
     tag_name: str,
     store: DataStoreDependency,
+    page: int | None = None,
+    per_page: int | None = None,
 ):
-    books = store.book_repo.get_books_by_tag(tag_name)
+    page, per_page_size = normalize_pagination(page, per_page)
+    books, total, page = store.book_repo.get_books_by_tag(tag_name, page=page, per_page=per_page_size)
     tags = []
     for book in books:
         tags.extend(iter(book.tags))
     tags = sorted(set(tags), key=lambda tag: tag.name)
-    return templates.TemplateResponse("books_list.html", {"request": request, "books": books, "tags": tags})
+    pagination = Pagination(
+        request=request,
+        route_name="show_books_by_tag",
+        route_kwargs={"tag_name": tag_name},
+        page=page,
+        per_page=per_page_size,
+        total=total,
+    )
+    return templates.TemplateResponse(
+        "books_list.html",
+        {
+            "request": request,
+            "books": books,
+            "tags": tags,
+            "pagination": pagination,
+            "per_page": per_page_size,
+            "default_per_page": DEFAULT_PER_PAGE,
+        },
+    )
 
 
 @router.post("/books/{book_id}/tags")

--- a/app/handlers/home/views.py
+++ b/app/handlers/home/views.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Request
 
 from app.handlers.dependencies import DataStoreDependency
-from app.template_utils import templates
+from app.template_utils import DEFAULT_PER_PAGE, Pagination, normalize_pagination, templates
 
 router = APIRouter()
 
@@ -10,7 +10,27 @@ router = APIRouter()
 def homepage(
     request: Request,
     store: DataStoreDependency,
+    page: int | None = None,
+    per_page: int | None = None,
 ):
-    books = store.book_repo.get_all_books()
+    page, per_page_size = normalize_pagination(page, per_page)
+    books, total, page = store.book_repo.get_all_books(page=page, per_page=per_page_size)
     tags = store.book_repo.get_tags_linked_to_books()
-    return templates.TemplateResponse("index.html", {"request": request, "books": books, "tags": tags})
+    pagination = Pagination(
+        request=request,
+        route_name="homepage",
+        page=page,
+        per_page=per_page_size,
+        total=total,
+    )
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "books": books,
+            "tags": tags,
+            "pagination": pagination,
+            "per_page": per_page_size,
+            "default_per_page": DEFAULT_PER_PAGE,
+        },
+    )

--- a/app/repositories/book_repository.py
+++ b/app/repositories/book_repository.py
@@ -7,6 +7,10 @@ from app.models.publishers import Publisher
 from app.repositories.base import AbstractRepository
 
 
+def _total_pages(total: int, per_page: int) -> int:
+    return max(1, (total + per_page - 1) // per_page) if total else 1
+
+
 class BookRepository(AbstractRepository):
     def get_tags_linked_to_books(self):
         tags_query = (
@@ -18,27 +22,32 @@ class BookRepository(AbstractRepository):
         )
         return self.session.scalars(tags_query).all()
 
-    def get_searched_books(self, query: str) -> list[Book]:
+    def get_searched_books(self, query: str, page: int = 1, per_page: int = 20) -> tuple[list[Book], int, int]:
         pattern = f"%{query}%"
-        return (
+        where = or_(
+            Book.title.ilike(pattern),
+            Book.isbn.ilike(pattern),
+            Book.description.ilike(pattern),
+            Book.edition.ilike(pattern),
+            Book.authors.any(Author.name.ilike(pattern)),
+            Book.tags.any(Tag.name.ilike(pattern)),
+            Book.publisher.has(Publisher.name.ilike(pattern)),
+            Book.series.has(BookSeries.name.ilike(pattern)),
+            Book.collection.has(Collection.name.ilike(pattern)),
+        )
+        total = self.session.scalar(select(func.count()).select_from(Book).where(where)) or 0
+        page = max(1, min(page, _total_pages(total, per_page)))
+        books = (
             self.session
             .scalars(
                 select(Book)
-                .where(
-                    or_(
-                        Book.title.ilike(pattern),
-                        Book.isbn.ilike(pattern),
-                        Book.description.ilike(pattern),
-                        Book.edition.ilike(pattern),
-                        Book.authors.any(Author.name.ilike(pattern)),
-                        Book.tags.any(Tag.name.ilike(pattern)),
-                        Book.publisher.has(Publisher.name.ilike(pattern)),
-                        Book.series.has(BookSeries.name.ilike(pattern)),
-                        Book.collection.has(Collection.name.ilike(pattern)),
-                    )
-                )
+                .where(where)
+                .order_by(Book.id.asc())
+                .offset((page - 1) * per_page)
+                .limit(per_page)
             ).all()
         )
+        return books, total, page
 
     def get_book_by_id(self, book_id: int) -> Book:
         book = (
@@ -54,17 +63,36 @@ class BookRepository(AbstractRepository):
         )
         return book
 
-    def get_books_by_tag(self, tag_name: str) -> list[Book]:
-        return (
+    def get_books_by_tag(self, tag_name: str, page: int = 1, per_page: int = 20) -> tuple[list[Book], int, int]:
+        where = Book.tags.any(name=tag_name)
+        total = self.session.scalar(select(func.count()).select_from(Book).where(where)) or 0
+        page = max(1, min(page, _total_pages(total, per_page)))
+        books = (
             self.session
             .scalars(
                 select(Book)
-                .where(Book.tags.any(name=tag_name))
+                .where(where)
+                .order_by(Book.id.asc())
+                .offset((page - 1) * per_page)
+                .limit(per_page)
             )
             .all())
+        return books, total, page
 
-    def get_all_books(self):
-        return self.session.scalars(select(Book)).all()
+    def get_all_books(self, page: int = 1, per_page: int = 20) -> tuple[list[Book], int, int]:
+        total = self.session.scalar(select(func.count()).select_from(Book)) or 0
+        page = max(1, min(page, _total_pages(total, per_page)))
+        books = (
+            self.session
+            .scalars(
+                select(Book)
+                .order_by(Book.id.asc())
+                .offset((page - 1) * per_page)
+                .limit(per_page)
+            )
+            .all()
+        )
+        return books, total, page
 
     def add_tag(self, book: Book, tag: Tag) -> None:
         if tag not in book.tags:

--- a/app/template_utils.py
+++ b/app/template_utils.py
@@ -1,3 +1,53 @@
+from starlette.requests import Request
 from starlette.templating import Jinja2Templates
 
 templates = Jinja2Templates(directory="templates")
+
+ALLOWED_PER_PAGE = (20, 50, 100)
+DEFAULT_PER_PAGE = 20
+
+
+class Pagination:
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        request: Request,
+        route_name: str,
+        page: int,
+        per_page: int,
+        total: int,
+        route_kwargs: dict | None = None,
+        extra_query: dict | None = None,
+    ):
+        self.request = request
+        self.route_name = route_name
+        self.route_kwargs = route_kwargs or {}
+        self.page = page
+        self.per_page = per_page
+        self.total = total
+        self._extra_query = extra_query or {}
+
+    @property
+    def total_pages(self) -> int:
+        if self.total == 0:
+            return 1
+        return (self.total + self.per_page - 1) // self.per_page
+
+    @property
+    def has_prev(self) -> bool:
+        return self.page > 1
+
+    @property
+    def has_next(self) -> bool:
+        return self.page < self.total_pages
+
+    def url_for(self, page: int, per_page: int | None = None) -> str:
+        params = {**self._extra_query, "page": page, "per_page": per_page if per_page is not None else self.per_page}
+        url = self.request.url_for(self.route_name, **self.route_kwargs)
+        return str(url.include_query_params(**params))
+
+
+def normalize_pagination(page: int | None, per_page: int | None) -> tuple[int, int]:
+    p = max(1, page or 1)
+    size = per_page if per_page in ALLOWED_PER_PAGE else DEFAULT_PER_PAGE
+    return p, size

--- a/templates/books_list.html
+++ b/templates/books_list.html
@@ -130,6 +130,54 @@
                 {% endfor %}
             </form>
         </div>
+
+        <!-- Pagination footer -->
+        {% if pagination is defined and pagination.total > 0 %}
+        <div class="flex-shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-gray-50 border-t border-gray-200 text-sm">
+            <div class="text-gray-600">
+                {{ pagination.total }} book{{ 's' if pagination.total != 1 else '' }}
+                &middot;
+                page {{ pagination.page }} of {{ pagination.total_pages }}
+            </div>
+
+            <div class="flex items-center gap-1">
+                {% if pagination.has_prev %}
+                <a hx-get="{{ pagination.url_for(pagination.page - 1) }}" hx-target="#books-list" hx-push-url="true"
+                    class="px-3 py-1 rounded border border-gray-300 bg-white hover:bg-gray-100 text-gray-700">Prev</a>
+                {% else %}
+                <span class="px-3 py-1 rounded border border-gray-200 bg-gray-100 text-gray-400 cursor-not-allowed">Prev</span>
+                {% endif %}
+
+                {% for p in range(1, pagination.total_pages + 1) %}
+                    {% if p == pagination.page %}
+                    <span class="px-3 py-1 rounded border border-blue-500 bg-blue-500 text-white">{{ p }}</span>
+                    {% else %}
+                    <a hx-get="{{ pagination.url_for(p) }}" hx-target="#books-list" hx-push-url="true"
+                        class="px-3 py-1 rounded border border-gray-300 bg-white hover:bg-gray-100 text-gray-700">{{ p }}</a>
+                    {% endif %}
+                {% endfor %}
+
+                {% if pagination.has_next %}
+                <a hx-get="{{ pagination.url_for(pagination.page + 1) }}" hx-target="#books-list" hx-push-url="true"
+                    class="px-3 py-1 rounded border border-gray-300 bg-white hover:bg-gray-100 text-gray-700">Next</a>
+                {% else %}
+                <span class="px-3 py-1 rounded border border-gray-200 bg-gray-100 text-gray-400 cursor-not-allowed">Next</span>
+                {% endif %}
+            </div>
+
+            <div class="flex items-center gap-1">
+                <span class="text-gray-600 mr-1">Per page:</span>
+                {% for size in (20, 50, 100) %}
+                    {% if size == pagination.per_page %}
+                    <span class="px-2 py-1 rounded border border-blue-500 bg-blue-500 text-white">{{ size }}</span>
+                    {% else %}
+                    <a hx-get="{{ pagination.url_for(1, size) }}" hx-target="#books-list" hx-push-url="true"
+                        class="px-2 py-1 rounded border border-gray-300 bg-white hover:bg-gray-100 text-gray-700">{{ size }}</a>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
     </div>
 </div>
 

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -26,7 +26,7 @@
 
         <div class="flex items-center">
             <div class="relative">
-                <form hx-post="{{ url_for('search_books') }}" hx-trigger="submit" hx-target="#books-list">
+                <form hx-get="{{ url_for('search_books') }}" hx-trigger="submit" hx-target="#books-list">
                     <input type="text" id="search-navbar"
                         class="block w-full p-2 pl-2 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
                         name="query" placeholder="Search...">


### PR DESCRIPTION
Paginate homepage, search, and by_tag routes server-side with page-number controls, per-page selector (20/50/100), and out-of-range page clamping.

- BookRepository: get_all_books, get_searched_books, get_books_by_tag now accept page/per_page and return (books, total, page); all ordered by Book.id for deterministic pagination
- template_utils: Pagination helper builds hx-get URLs preserving query params (e.g. ?query=…); normalize_pagination clamps per_page to {20, 50, 100}
- handlers: home + books list routes accept page/per_page query params and pass Pagination to the template; search_books switched POST→GET so pagination links can fetch subsequent pages
- books_list.html: pagination footer (prev/next, page numbers, per-page selector) with hx-get + hx-push-url for bookmarkable pages
- navbar.html: search form hx-post→hx-get to match the handler change