### PR TITLE
Add column sorting to book list (#113)

### DIFF
--- a/app/handlers/books/views.py
+++ b/app/handlers/books/views.py
@@ -16,7 +16,7 @@ from starlette.responses import RedirectResponse
 
 from app.handlers.dependencies import DataStoreDependency
 from app.services.importers import DjvuImporter, EpubImporter, PdfImporter
-from app.template_utils import DEFAULT_PER_PAGE, Pagination, normalize_pagination, templates
+from app.template_utils import DEFAULT_PER_PAGE, Pagination, normalize_pagination, normalize_sort, templates
 
 ALLOWED_TYPES = {
     "application/pdf": PdfImporter,
@@ -28,15 +28,18 @@ router = APIRouter()
 
 
 @router.get("/search", summary="Search books", status_code=status.HTTP_200_OK)
-def search_books(
+def search_books(  # noqa: PLR0913
     request: Request,
     store: DataStoreDependency,
     query: str = Query(default=""),
     page: int | None = None,
     per_page: int | None = None,
+    sort_by: str | None = None,
+    order: str | None = None,
 ):
     page, per_page_size = normalize_pagination(page, per_page)
-    books, total, page = store.book_repo.get_searched_books(query, page=page, per_page=per_page_size)
+    sort_by, sort_order = normalize_sort(sort_by, order)
+    books, total, page = store.book_repo.get_searched_books(query, page=page, per_page=per_page_size, sort_by=sort_by, order=sort_order)
     tags = []
     for book in books:
         tags.extend(iter(book.tags))
@@ -47,6 +50,8 @@ def search_books(
         page=page,
         per_page=per_page_size,
         total=total,
+        sort_by=sort_by,
+        sort_order=sort_order,
         extra_query={"query": query} if query else {},
     )
     return templates.TemplateResponse(
@@ -120,15 +125,18 @@ def download_book(
 
 
 @router.get("/by_tag/{tag_name}")
-def show_books_by_tag(
+def show_books_by_tag(  # noqa: PLR0913
     request: Request,
     tag_name: str,
     store: DataStoreDependency,
     page: int | None = None,
     per_page: int | None = None,
+    sort_by: str | None = None,
+    order: str | None = None,
 ):
     page, per_page_size = normalize_pagination(page, per_page)
-    books, total, page = store.book_repo.get_books_by_tag(tag_name, page=page, per_page=per_page_size)
+    sort_by, sort_order = normalize_sort(sort_by, order)
+    books, total, page = store.book_repo.get_books_by_tag(tag_name, page=page, per_page=per_page_size, sort_by=sort_by, order=sort_order)
     tags = []
     for book in books:
         tags.extend(iter(book.tags))
@@ -140,6 +148,8 @@ def show_books_by_tag(
         page=page,
         per_page=per_page_size,
         total=total,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
     return templates.TemplateResponse(
         "books_list.html",

--- a/app/handlers/home/views.py
+++ b/app/handlers/home/views.py
@@ -1,20 +1,23 @@
 from fastapi import APIRouter, Request
 
 from app.handlers.dependencies import DataStoreDependency
-from app.template_utils import DEFAULT_PER_PAGE, Pagination, normalize_pagination, templates
+from app.template_utils import DEFAULT_PER_PAGE, Pagination, normalize_pagination, normalize_sort, templates
 
 router = APIRouter()
 
 
 @router.get("/")
-def homepage(
+def homepage(  # noqa: PLR0913
     request: Request,
     store: DataStoreDependency,
     page: int | None = None,
     per_page: int | None = None,
+    sort_by: str | None = None,
+    order: str | None = None,
 ):
     page, per_page_size = normalize_pagination(page, per_page)
-    books, total, page = store.book_repo.get_all_books(page=page, per_page=per_page_size)
+    sort_by, sort_order = normalize_sort(sort_by, order)
+    books, total, page = store.book_repo.get_all_books(page=page, per_page=per_page_size, sort_by=sort_by, order=sort_order)
     tags = store.book_repo.get_tags_linked_to_books()
     pagination = Pagination(
         request=request,
@@ -22,6 +25,8 @@ def homepage(
         page=page,
         per_page=per_page_size,
         total=total,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
     return templates.TemplateResponse(
         "index.html",

--- a/app/repositories/book_repository.py
+++ b/app/repositories/book_repository.py
@@ -6,23 +6,40 @@ from app.models.author import Author
 from app.models.publishers import Publisher
 from app.repositories.base import AbstractRepository
 
+SORTABLE_COLUMNS = frozenset({"title", "added_at", "edition", "publisher_id", "language_code"})
+DEFAULT_SORT_BY = "title"
+DEFAULT_SORT_ORDER = "asc"
+
 
 def _total_pages(total: int, per_page: int) -> int:
     return max(1, (total + per_page - 1) // per_page) if total else 1
 
 
+def _order_clause(sort_by: str, order: str):
+    # whitelist via getattr prevents SQL injection: arbitrary column names
+    # cannot reach the SQL. Invalid sort_by falls back to the default.
+    column_name = sort_by if sort_by in SORTABLE_COLUMNS else DEFAULT_SORT_BY
+    direction = "desc" if order.lower() == "desc" else "asc"
+    column = getattr(Book, column_name)
+    ordered = column.desc() if direction == "desc" else column.asc()
+    # always tiebreak by id so paginated rows are stable across pages when the
+    # sort column has many duplicate values (e.g. publisher_id=NULL).
+    return ordered, Book.id.asc()
+
+
 class BookRepository(AbstractRepository):
     def get_tags_linked_to_books(self):
-        tags_query = (
-            select(Tag)
-            .join(Tag.books)
-            .group_by(Tag.id)
-            .having(func.count(Book.id) > 0)
-            .order_by(Tag.name)
-        )
+        tags_query = select(Tag).join(Tag.books).group_by(Tag.id).having(func.count(Book.id) > 0).order_by(Tag.name)
         return self.session.scalars(tags_query).all()
 
-    def get_searched_books(self, query: str, page: int = 1, per_page: int = 20) -> tuple[list[Book], int, int]:
+    def get_searched_books(
+        self,
+        query: str,
+        page: int = 1,
+        per_page: int = 20,
+        sort_by: str = DEFAULT_SORT_BY,
+        order: str = DEFAULT_SORT_ORDER,
+    ) -> tuple[list[Book], int, int]:
         pattern = f"%{query}%"
         where = or_(
             Book.title.ilike(pattern),
@@ -37,61 +54,46 @@ class BookRepository(AbstractRepository):
         )
         total = self.session.scalar(select(func.count()).select_from(Book).where(where)) or 0
         page = max(1, min(page, _total_pages(total, per_page)))
-        books = (
-            self.session
-            .scalars(
-                select(Book)
-                .where(where)
-                .order_by(Book.id.asc())
-                .offset((page - 1) * per_page)
-                .limit(per_page)
-            ).all()
-        )
+        primary, tiebreaker = _order_clause(sort_by, order)
+        books = self.session.scalars(
+            select(Book).where(where).order_by(primary, tiebreaker).offset((page - 1) * per_page).limit(per_page)
+        ).all()
         return books, total, page
 
     def get_book_by_id(self, book_id: int) -> Book:
-        book = (
-            self.session
-            .scalar(
-                select(Book)
-                .options(
-                    joinedload(Book.tags)
-                )
-                .where(
-                    Book.id == book_id)
-            )
-        )
+        book = self.session.scalar(select(Book).options(joinedload(Book.tags)).where(Book.id == book_id))
         return book
 
-    def get_books_by_tag(self, tag_name: str, page: int = 1, per_page: int = 20) -> tuple[list[Book], int, int]:
+    def get_books_by_tag(
+        self,
+        tag_name: str,
+        page: int = 1,
+        per_page: int = 20,
+        sort_by: str = DEFAULT_SORT_BY,
+        order: str = DEFAULT_SORT_ORDER,
+    ) -> tuple[list[Book], int, int]:
         where = Book.tags.any(name=tag_name)
         total = self.session.scalar(select(func.count()).select_from(Book).where(where)) or 0
         page = max(1, min(page, _total_pages(total, per_page)))
-        books = (
-            self.session
-            .scalars(
-                select(Book)
-                .where(where)
-                .order_by(Book.id.asc())
-                .offset((page - 1) * per_page)
-                .limit(per_page)
-            )
-            .all())
+        primary, tiebreaker = _order_clause(sort_by, order)
+        books = self.session.scalars(
+            select(Book).where(where).order_by(primary, tiebreaker).offset((page - 1) * per_page).limit(per_page)
+        ).all()
         return books, total, page
 
-    def get_all_books(self, page: int = 1, per_page: int = 20) -> tuple[list[Book], int, int]:
+    def get_all_books(
+        self,
+        page: int = 1,
+        per_page: int = 20,
+        sort_by: str = DEFAULT_SORT_BY,
+        order: str = DEFAULT_SORT_ORDER,
+    ) -> tuple[list[Book], int, int]:
         total = self.session.scalar(select(func.count()).select_from(Book)) or 0
         page = max(1, min(page, _total_pages(total, per_page)))
-        books = (
-            self.session
-            .scalars(
-                select(Book)
-                .order_by(Book.id.asc())
-                .offset((page - 1) * per_page)
-                .limit(per_page)
-            )
-            .all()
-        )
+        primary, tiebreaker = _order_clause(sort_by, order)
+        books = self.session.scalars(
+            select(Book).order_by(primary, tiebreaker).offset((page - 1) * per_page).limit(per_page)
+        ).all()
         return books, total, page
 
     def add_tag(self, book: Book, tag: Tag) -> None:

--- a/app/template_utils.py
+++ b/app/template_utils.py
@@ -1,10 +1,18 @@
 from starlette.requests import Request
 from starlette.templating import Jinja2Templates
 
+from app.repositories.book_repository import (
+    DEFAULT_SORT_BY,
+    DEFAULT_SORT_ORDER,
+    SORTABLE_COLUMNS,
+)
+
 templates = Jinja2Templates(directory="templates")
 
 ALLOWED_PER_PAGE = (20, 50, 100)
 DEFAULT_PER_PAGE = 20
+
+ALLOWED_SORT_ORDERS = ("asc", "desc")
 
 
 class Pagination:
@@ -16,6 +24,8 @@ class Pagination:
         page: int,
         per_page: int,
         total: int,
+        sort_by: str,
+        sort_order: str,
         route_kwargs: dict | None = None,
         extra_query: dict | None = None,
     ):
@@ -25,6 +35,8 @@ class Pagination:
         self.page = page
         self.per_page = per_page
         self.total = total
+        self.sort_by = sort_by
+        self.sort_order = sort_order
         self._extra_query = extra_query or {}
 
     @property
@@ -41,13 +53,44 @@ class Pagination:
     def has_next(self) -> bool:
         return self.page < self.total_pages
 
-    def url_for(self, page: int, per_page: int | None = None) -> str:
-        params = {**self._extra_query, "page": page, "per_page": per_page if per_page is not None else self.per_page}
+    def _build_url(self, **overrides) -> str:
+        params = {
+            **self._extra_query,
+            "page": self.page,
+            "per_page": self.per_page,
+            "sort_by": self.sort_by,
+            "order": self.sort_order,
+            **overrides,
+        }
         url = self.request.url_for(self.route_name, **self.route_kwargs)
         return str(url.include_query_params(**params))
 
+    def url_for(self, page: int, per_page: int | None = None) -> str:
+        return self._build_url(page=page, per_page=per_page if per_page is not None else self.per_page)
 
-def normalize_pagination(page: int | None, per_page: int | None) -> tuple[int, int]:
+    def sort_url(self, column: str) -> str:
+        # clicking the active column toggles direction; a new column starts asc.
+        # Resetting to page 1 keeps results stable across sort changes.
+        new_order = ("asc" if self.sort_order == "desc" else "desc") if column == self.sort_by else "asc"
+        return self._build_url(sort_by=column, order=new_order, page=1)
+
+    def is_sorted(self, column: str) -> bool:
+        return column == self.sort_by
+
+
+def normalize_pagination(
+    page: int | None,
+    per_page: int | None,
+) -> tuple[int, int]:
     p = max(1, page or 1)
     size = per_page if per_page in ALLOWED_PER_PAGE else DEFAULT_PER_PAGE
     return p, size
+
+
+def normalize_sort(
+    sort_by: str | None,
+    order: str | None,
+) -> tuple[str, str]:
+    by = sort_by if sort_by in SORTABLE_COLUMNS else DEFAULT_SORT_BY
+    direction = order if order in ALLOWED_SORT_ORDERS else DEFAULT_SORT_ORDER
+    return by, direction

--- a/templates/books_list.html
+++ b/templates/books_list.html
@@ -35,10 +35,34 @@
                     <input type="checkbox" id="select-all" class="form-checkbox h-4 w-4 text-blue-600">
                 </div>
                 <div class="col-span-1"></div>
-                <div class="col-span-3">Title & Author</div>
-                <div class="col-span-2">Publisher</div>
-                <div class="col-span-1">Language</div>
-                <div class="col-span-2">Added</div>
+                <div class="col-span-3">
+                    <a hx-get="{{ pagination.sort_url('title') }}" hx-target="#books-list" hx-push-url="true"
+                        class="inline-flex items-center gap-1 hover:text-blue-600 cursor-pointer">
+                        Title &amp; Author
+                        {% if pagination.is_sorted('title') %}<span class="text-blue-600">{{ '▼' if pagination.sort_order == 'desc' else '▲' }}</span>{% endif %}
+                    </a>
+                </div>
+                <div class="col-span-2">
+                    <a hx-get="{{ pagination.sort_url('publisher_id') }}" hx-target="#books-list" hx-push-url="true"
+                        class="inline-flex items-center gap-1 hover:text-blue-600 cursor-pointer">
+                        Publisher
+                        {% if pagination.is_sorted('publisher_id') %}<span class="text-blue-600">{{ '▼' if pagination.sort_order == 'desc' else '▲' }}</span>{% endif %}
+                    </a>
+                </div>
+                <div class="col-span-1">
+                    <a hx-get="{{ pagination.sort_url('language_code') }}" hx-target="#books-list" hx-push-url="true"
+                        class="inline-flex items-center gap-1 hover:text-blue-600 cursor-pointer">
+                        Language
+                        {% if pagination.is_sorted('language_code') %}<span class="text-blue-600">{{ '▼' if pagination.sort_order == 'desc' else '▲' }}</span>{% endif %}
+                    </a>
+                </div>
+                <div class="col-span-2">
+                    <a hx-get="{{ pagination.sort_url('added_at') }}" hx-target="#books-list" hx-push-url="true"
+                        class="inline-flex items-center gap-1 hover:text-blue-600 cursor-pointer">
+                        Added
+                        {% if pagination.is_sorted('added_at') %}<span class="text-blue-600">{{ '▼' if pagination.sort_order == 'desc' else '▲' }}</span>{% endif %}
+                    </a>
+                </div>
                 <div class="col-span-2">Tags</div>
             </div>
         </div>


### PR DESCRIPTION
Sort the book list by clicking column headers. Whitelisted columns are title, added_at, edition, publisher_id, language_code (getattr on Book prevents arbitrary column access / SQL injection). Clicking the active column toggles direction; a new column starts at asc and resets to page 1.

- BookRepository: sort_by/order on get_all_books, get_searched_books, get_books_by_tag; _order_clause whitelists columns, always tiebreaks by Book.id for stable pagination across duplicates
- template_utils: Pagination carries sort_by/sort_order and includes them in url_for so pagination/per-page links preserve the current sort; new sort_url(column) for header links, is_sorted(column) for arrows; normalize_sort validates input against the whitelist
- handlers: home + books list routes accept sort_by/order query params
- books_list.html: Title, Publisher, Language, Added headers are hx-get links; active column shows ▲/▼ indicator